### PR TITLE
Add GPT partition table support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ volume_partitions:
   - name: mysql
     number: 1
     path: /var/lib/mysql
+    label: msdos
     filesystem: ext4
     device: /dev/sdb
     options:
@@ -57,6 +58,7 @@ volume_partitions:
   - name: foobar
     number: 1
     path: /var/lib/foobar
+    label: gpt
     filesystem: ext4
     device: /dev/sdc
     state: present

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@
 #   - name: mysql
 #     number: 1
 #     path: /var/lib/mysql
+#     label: msdos
 #     filesystem: ext4
 #     device: /dev/sdb
 #     options:
@@ -14,6 +15,7 @@
 #   - name: foobar
 #     number: 1
 #     path: /var/lib/foobar
+#     label: gpt
 #     filesystem: ext4
 #     device: /dev/sdc
 #     state: present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
     device: "{{ item.device }}"
     number: "{{ item.number }}"
     label: "{{ omit if item.label is undefined else item.label }}"
-    name: "{% if item.label == 'gpt' %}GPT{% endif %}"
+    name: "{{ 'GPT' if item.label == 'gpt' else omit }}"
     flags: "{{ item.flags | default([]) }}"
     state: "{{ item.state | default('present') }}"
     part_start: "{{ item.part_start | default('0%') }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
   community.general.parted:
     device: "{{ item.device }}"
     number: "{{ item.number }}"
-    label: "{{ item.label | default('msdos') }}"
+    label: "{{ omit if item.label is undefined else item.label }}"
     name: "{% if item.label == 'gpt' %}GPT{% endif %}"
     flags: "{{ item.flags | default([]) }}"
     state: "{{ item.state | default('present') }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,8 @@
   community.general.parted:
     device: "{{ item.device }}"
     number: "{{ item.number }}"
+    label: "{{ item.label | default('msdos') }}"
+    name: "{% if item.label == 'gpt' %}GPT{% endif %}"
     flags: "{{ item.flags | default([]) }}"
     state: "{{ item.state | default('present') }}"
     part_start: "{{ item.part_start | default('0%') }}"


### PR DESCRIPTION
**Feature description**

This pull request slightly extends the role’s functionality by adding support for creating GPT partition tables on new disks and allowing users to choose the desired partition table label. Previously, the role implicitly worked with MBR (msdos) only.

The documentation at [this link](https://docs.ansible.com/ansible/latest/collections/community/general/parted_module.html#parameter-label) explains why I added a condition to the name field.

**What’s included**

- Support for GPT partition tables in addition to MBR (msdos)
- Backward-compatible defaults (msdos remains the default if not specified)

**Why**

- The volume size in the MBR table is limited to 2TB
- GPT is the modern standard for larger disks and UEFI-based systems
- Provides flexibility to select the partition table type according to deployment needs
- Keeps existing behavior unchanged for current users

**Compatibility and notes**

- No breaking changes: existing inventories that don’t set a label continue to use msdos
- Idempotent behavior preserved
- Does not require changes for existing users unless they want GPT

I’d appreciate a review and feedback. Thanks!